### PR TITLE
Upgraded to react v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "mocha": "^3.5.0",
     "normalize.css": "^7.0.0",
     "nyc": "^11.1.0",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
Issue #30 
As it is written in [react upgrade guide](https://facebook.github.io/react/blog/2017/09/26/react-v16.0.html#upgrading), if your app worked in v15.6 it should work fine now. I checked it, and all tests passed, and there is no usage of any function/feature that had a breaking change introduced in v16