### PR TITLE
GetDefaults now ignores oneOf

### DIFF
--- a/lib/get-defaults.js
+++ b/lib/get-defaults.js
@@ -2,7 +2,6 @@
 
 function getDefaults (schema) {
     if (typeof schema !== 'object') { return; }
-    if (schema.oneOf !== undefined) { return ''; }
 
     if (schema.default !== undefined) {
         return schema.default;


### PR DESCRIPTION
genDefaults was returning an empty string whenever it sees oneOf property. That leads to the problem that resch doesn't properly handle some json schemas which had default values for some properties.